### PR TITLE
fix: sitemaps should not use subdirectory

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,9 +33,9 @@ const nextConfig = {
 					"https://raw.githubusercontent.com/Crossbell-Box/io-sitemap/main/sitemaps/sitemap-index.xml",
 			},
 			{
-				source: "/sitemaps/:match*",
+				source: "/sitemap-:match*.xml",
 				destination:
-					"https://raw.githubusercontent.com/Crossbell-Box/io-sitemap/main/sitemaps/:match*",
+					"https://raw.githubusercontent.com/Crossbell-Box/io-sitemap/main/sitemaps/sitemap-:match*.xml",
 			},
 			{
 				source: "/robots.txt",


### PR DESCRIPTION
https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap#general-guidelines

See also Crossbell-Box/io-sitemap#3