### PR TITLE
fix(aside/AchievementSection): display only minted level

### DIFF
--- a/components/aside/AchievementSection/badges.tsx
+++ b/components/aside/AchievementSection/badges.tsx
@@ -126,7 +126,6 @@ function useBadgeInfos(mintedAchievements: AchievementInfo[]) {
 				mintedAchievements.map((achievement) => {
 					const highestLevel = getHighestLevel(achievement.levels, [
 						AchievementLevelStatus.minted,
-						AchievementLevelStatus.ableToMint,
 					]);
 
 					return highestLevel ? { achievement, highestLevel } : null;


### PR DESCRIPTION
To avoid un-minted level display

#### Before
<img width="411" alt="image" src="https://user-images.githubusercontent.com/12002941/197270576-a3f90300-5c68-49e6-ba5d-a24be6531dc8.png">

#### After
<img width="373" alt="image" src="https://user-images.githubusercontent.com/12002941/197270644-e6f3de88-14b7-427f-8364-bbc8ed2361cc.png">
