### PR TITLE
fix(crossbell.io/note): note-likes modal zIndex issue

### DIFF
--- a/sites/crossbell.io/components/common/Note/components/note-likes/index.tsx
+++ b/sites/crossbell.io/components/common/Note/components/note-likes/index.tsx
@@ -90,6 +90,7 @@ export function NoteLikes({ model }: NoteLikesProps) {
 			<Modal
 				radius={28}
 				padding={0}
+				zIndex={11}
 				withCloseButton={false}
 				opened={isModalOpened}
 				onClose={modal.close}


### PR DESCRIPTION
`connect-kit` modal is covered by `note-likes` modal